### PR TITLE
There are two prefixes for topics generated from branch filtering: "b…

### DIFF
--- a/_js/lib/EditController.js
+++ b/_js/lib/EditController.js
@@ -28,6 +28,9 @@ define([
           let file = htmlURL.endsWith('.html') ?
           htmlURL.slice('/dev/'.length, htmlURL.length - '.html'.length) + '.dita' :
           htmlURL.slice('/dev/'.length, htmlURL.length) + 'index.dita'
+          if(file.indexOf('/first-build-') != -1) {
+            file = file.replace('first-build-', '')
+          }
           if(file.indexOf('/build-') != -1) {
             file = file.replace('build-', '')
           }


### PR DESCRIPTION
…uild-" and "first-build-". We handled the first but not the second, this takes into account also the "first-build" prefix. Checked the entire map running //dvrResourcePrefix on all maps, there are no other prefixes. used.