### PR TITLE
Add banner to development documentation

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,0 +1,12 @@
+<div class="alert alert-warning alert-dismissible" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <p>
+    <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
+    <span class="note__title notetitle"> Development documentation</span> may describe unreleased features and options. Switch to the latest
+    <a href="{{ site.baseurl }}/{{ site.release }}" class="alert-link">release documentation</a> →
+    <a class="btn btn-default btn-xs btn-warning" href="{{ site.baseurl }}/{{ site.release }}">
+    <span class="glyphicon glyphicon-book" aria-hidden="true"></span> {{ site.release }} Docs</a>
+  </p>
+</div>

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -4,8 +4,8 @@
   </button>
   <p>
     <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
-    <span class="note__title notetitle"> Development documentation</span> may describe unreleased features and options. Switch to the latest
-    <a href="{{ site.baseurl }}/{{ site.release }}" class="alert-link">release documentation</a> →
+    <span class="note__title notetitle"> Development documentation</span> might describe unreleased features and options. Switch to the latest
+    <a href="{{ site.baseurl }}/{{ site.release }}" class="alert-link">released documentation</a>:
     <a class="btn btn-default btn-xs btn-warning" href="{{ site.baseurl }}/{{ site.release }}">
     <span class="glyphicon glyphicon-book" aria-hidden="true"></span> {{ site.release }} Docs</a>
   </p>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -18,6 +18,9 @@
     {% include header.html %}
     <div id="content" class="container-fluid container">
       <div class="row">
+        {% if page.url contains '/dev/' %}
+          {% include banner.html %}
+        {% endif %}
         {{ content }}
       </div>
     </div>

--- a/css/_bootstrap-custom.scss
+++ b/css/_bootstrap-custom.scss
@@ -5,52 +5,52 @@
  */
 
 // Core variables and mixins
-@import "bootstrap/variables";
-@import "bootstrap/mixins";
+@import 'bootstrap/variables';
+@import 'bootstrap/mixins';
 
 // Reset and dependencies
-@import "bootstrap/normalize";
-@import "bootstrap/print";
-@import "bootstrap/glyphicons";
+@import 'bootstrap/normalize';
+@import 'bootstrap/print';
+@import 'bootstrap/glyphicons';
 
 // Core CSS
-@import "bootstrap/scaffolding";
-@import "bootstrap/type";
-@import "bootstrap/code";
-@import "bootstrap/grid";
-@import "bootstrap/tables";
-@import "bootstrap/forms";
-@import "bootstrap/buttons";
+@import 'bootstrap/scaffolding';
+@import 'bootstrap/type';
+@import 'bootstrap/code';
+@import 'bootstrap/grid';
+@import 'bootstrap/tables';
+@import 'bootstrap/forms';
+@import 'bootstrap/buttons';
 
 // Components
-// @import "bootstrap/component-animations";
-@import "bootstrap/dropdowns";
-// @import "bootstrap/button-groups";
-// @import "bootstrap/input-groups";
-@import "bootstrap/navs";
-@import "bootstrap/navbar";
-@import "bootstrap/breadcrumbs";
-// @import "bootstrap/pagination";
-// @import "bootstrap/pager";
-// @import "bootstrap/labels";
-// @import "bootstrap/badges";
-@import "bootstrap/jumbotron";
-// @import "bootstrap/thumbnails";
-@import "bootstrap/alerts";
-// @import "bootstrap/progress-bars";
-@import "bootstrap/media";
-// @import "bootstrap/list-group";
-// @import "bootstrap/panels";
-// @import "bootstrap/responsive-embed";
-@import "bootstrap/wells";
-@import "bootstrap/close";
+// @import 'bootstrap/component-animations';
+@import 'bootstrap/dropdowns';
+// @import 'bootstrap/button-groups';
+// @import 'bootstrap/input-groups';
+@import 'bootstrap/navs';
+@import 'bootstrap/navbar';
+@import 'bootstrap/breadcrumbs';
+// @import 'bootstrap/pagination';
+// @import 'bootstrap/pager';
+// @import 'bootstrap/labels';
+// @import 'bootstrap/badges';
+@import 'bootstrap/jumbotron';
+// @import 'bootstrap/thumbnails';
+@import 'bootstrap/alerts';
+// @import 'bootstrap/progress-bars';
+@import 'bootstrap/media';
+// @import 'bootstrap/list-group';
+// @import 'bootstrap/panels';
+// @import 'bootstrap/responsive-embed';
+@import 'bootstrap/wells';
+@import 'bootstrap/close';
 
 // Components w/ JavaScript
-@import "bootstrap/modals";
-// @import "bootstrap/tooltip";
-// @import "bootstrap/popovers";
-// @import "bootstrap/carousel";
+@import 'bootstrap/modals';
+// @import 'bootstrap/tooltip';
+// @import 'bootstrap/popovers';
+// @import 'bootstrap/carousel';
 
 // Utility classes
-@import "bootstrap/utilities";
-@import "bootstrap/responsive-utilities";
+@import 'bootstrap/utilities';
+@import 'bootstrap/responsive-utilities';


### PR DESCRIPTION
As discussed in the [October contributor call](https://github.com/dita-ot/dita-ot/wiki/Meeting-minutes-2016-10-06), now that we are pointing people to the development version of the documentation to take advantage of the new **Edit this page** footers implemented for #8, we need a way to let people know that they are viewing the `dev` version of the documentation, which may describe unreleased features and options.

General consensus in the call was that a banner would be the best solution.