### PR TITLE
Remove year from FrameMaker listing

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ toc: false
       <ul>
         <li>Authoring tools
           <ul>
-            <li><a href="http://www.adobe.com/products/framemaker.html" target="_blank">Adobe FrameMaker (2015 release)</a></li>
+            <li><a href="http://www.adobe.com/products/framemaker.html" target="_blank">Adobe FrameMaker</a></li>
             <li><a href="http://www.oxygenxml.com" target="_blank">oXygen XML Editor</a></li>
             <li><a href="http://www.xmetal.com" target="_blank">XMetaL Author Enterprise</a></li>
           </ul>


### PR DESCRIPTION
Just deleted "(2015 release)" from "Adobe FrameMaker (2015 release)". The current release is 2017. It's better and more easy for the future to just say "Adobe FrameMaker".