### PR TITLE
Remove Google Analytics

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -32,16 +32,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/js/bootstrap.min.js" type="text/javascript"></script>
     <script src="{{ site.baseurl }}/js/main.js" type="text/javascript" ></script>
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-37132449-1']);
-      _gaq.push(['_trackPageview']);
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>
     <script type="text/javascript"> docsearch({
       apiKey: 'fdd89b9b35b9bd347f34111dbc1c6219',
       indexName: 'dita-ot',


### PR DESCRIPTION
Having Google Analytics (GA) requires us to describe what sort of user tracking we use and allow users to opt-out. An alternative is to remove GA completely from use. GA is not an important tool for us, so for now it's easier to remove it and accept that we don't know how our users interact with our site.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>